### PR TITLE
Better iPad support

### DIFF
--- a/LockScreen.xm
+++ b/LockScreen.xm
@@ -5,6 +5,8 @@
 #import "SIXLockScreenView.h"
 #import "SIXLockScreenViewController.h"
 
+#define isiPad ([(NSString *)[UIDevice currentDevice].model hasPrefix:@"iPad"])
+
 static NSMutableDictionary *settings;
 static bool enabled;
 static bool disableHome;
@@ -163,14 +165,27 @@ static void setIsLocked(bool locked) {
 - (void)orientationChanged:(NSNotification *)notification {
   [self layoutSix];
   self.sixController.statusBarBackground.frame = CGRectMake(0, 0, [UIScreen mainScreen].bounds.size.width, statusHeight);
-  self.sixController.topBar.frame = CGRectMake(0, statusHeight, [UIScreen mainScreen].bounds.size.width, 95);
-  self.sixController.bottomBar.frame = CGRectMake(0, [UIScreen mainScreen].bounds.size.height - 95, [UIScreen mainScreen].bounds.size.width, 95);
-  self.sixController.trackBackground.frame = CGRectMake(20, 20, [UIScreen mainScreen].bounds.size.width - 85, 52);
-  self.sixController.timeLabel.frame = CGRectMake(0, 5, [UIScreen mainScreen].bounds.size.width, 60);
-  self.sixController.dateLabel.frame = CGRectMake(0, 60, [UIScreen mainScreen].bounds.size.width, 30);
-  self.sixController.cameraGrabber.frame = CGRectMake([UIScreen mainScreen].bounds.size.width - 50, 21.5, 30, 52);
-  self.sixController.slideText.frame = CGRectMake(([UIScreen mainScreen].bounds.size.width / 2) - (([UIScreen mainScreen].bounds.size.width - 155) / 2) - 12.5, 11, [UIScreen mainScreen].bounds.size.width - 155, 30);
-  self.sixController.unlockSlider.frame = CGRectMake(23, [UIScreen mainScreen].bounds.size.height - 71, [UIScreen mainScreen].bounds.size.width - 91, 47);
+
+  if ( !isiPad ) { // If the user is on an iPhone
+    self.sixController.topBar.frame = CGRectMake(0, statusHeight, [UIScreen mainScreen].bounds.size.width, 95);
+    self.sixController.bottomBar.frame = CGRectMake(0, [UIScreen mainScreen].bounds.size.height - 95, [UIScreen mainScreen].bounds.size.width, 95);
+    self.sixController.trackBackground.frame = CGRectMake(20, 20, [UIScreen mainScreen].bounds.size.width - 85, 52);
+    self.sixController.timeLabel.frame = CGRectMake(0, 5, [UIScreen mainScreen].bounds.size.width, 60);
+    self.sixController.dateLabel.frame = CGRectMake(0, 60, [UIScreen mainScreen].bounds.size.width, 30);
+    self.sixController.cameraGrabber.frame = CGRectMake([UIScreen mainScreen].bounds.size.width - 50, 21.5, 30, 52);
+    self.sixController.slideText.frame = CGRectMake(([UIScreen mainScreen].bounds.size.width / 2) - (([UIScreen mainScreen].bounds.size.width - 155) / 2) - 12.5, 11, [UIScreen mainScreen].bounds.size.width - 155, 30);
+    self.sixController.unlockSlider.frame = CGRectMake(23, [UIScreen mainScreen].bounds.size.height - 71, [UIScreen mainScreen].bounds.size.width - 91, 47);
+  } else { // If the user is on an iPad
+    self.sixController.topBar.frame = CGRectMake(0, statusHeight, [UIScreen mainScreen].bounds.size.width, 100);
+    self.sixController.bottomBar.frame = CGRectMake(0, [UIScreen mainScreen].bounds.size.height - 100, [UIScreen mainScreen].bounds.size.width, 105);
+    self.sixController.trackBackground.frame = CGRectMake(([UIScreen mainScreen].bounds.size.width / 2) - 130, 25, 250, 52);
+    self.sixController.timeLabel.frame = CGRectMake(0, 10, [UIScreen mainScreen].bounds.size.width, 60);
+    self.sixController.dateLabel.frame = CGRectMake(0, 65, [UIScreen mainScreen].bounds.size.width, 30);
+    self.sixController.cameraGrabber.frame = CGRectMake([UIScreen mainScreen].bounds.size.width - 50, 21.5, 30, 52);
+    self.sixController.slideText.frame = CGRectMake(([UIScreen mainScreen].bounds.size.width / 2) - (([UIScreen mainScreen].bounds.size.width - 155) / 2) - 110, 11, 365, 30);
+    self.sixController.unlockSlider.frame = CGRectMake(([UIScreen mainScreen].bounds.size.width / 2) - 127, [UIScreen mainScreen].bounds.size.height - 71, 245, 47);
+  }
+  
   self.sixController.slideUpBackground.frame = CGRectMake(0, [UIScreen mainScreen].bounds.size.height, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height);
   if (self.sixController.notificationTable) {
     self.sixController.notificationTable.frame = CGRectMake(0, statusHeight + 95, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height - (statusHeight + 190));

--- a/SIXLockScreenViewController.m
+++ b/SIXLockScreenViewController.m
@@ -3,7 +3,10 @@
 #import "SIXLockScreenViewController.h"
 #import "SIXNotificationCell.h"
 
+#define isiPad ([(NSString *)[UIDevice currentDevice].model hasPrefix:@"iPad"])
+
 @implementation SIXLockScreenViewController
+
 - (void)layoutSix {
   if (self.view.center.y != self.view.bounds.size.height / 2) {
     [self.view setCenter:CGPointMake(self.view.center.x, [UIScreen mainScreen].bounds.size.height / 2)];
@@ -40,7 +43,7 @@
     self.timeLabel.backgroundColor = [UIColor clearColor];
     self.timeLabel.textColor = [UIColor whiteColor];
     self.timeLabel.textAlignment = NSTextAlignmentCenter;
-    self.timeLabel.font = [UIFont fontWithName:@"Helvetica-Light" size:58];
+    self.timeLabel.font = !isiPad ? [UIFont fontWithName:@"Helvetica-Light" size:58] : [UIFont fontWithName:@"Helvetica-Light" size:68];
     self.timeLabel.layer.masksToBounds = NO;
     self.timeLabel.layer.shadowOffset = CGSizeMake(0, -1);
     self.timeLabel.layer.shadowRadius = 0;
@@ -60,7 +63,7 @@
     self.dateLabel.layer.shadowOpacity = 0.4;
   }
 
-  if (!self.cameraGrabber) {
+  if (!self.cameraGrabber && !isiPad) {
     self.cameraGrabber = [[UIImageView alloc] initWithFrame:CGRectMake([UIScreen mainScreen].bounds.size.width - 50, 21.5, 30, 52)];
     self.cameraGrabber.image = [UIImage imageWithContentsOfFile:@"/Library/Application Support/Six/camera.png"];
     self.cameraGrabber.contentMode = UIViewContentModeScaleToFill;
@@ -171,6 +174,11 @@
   self.slideText.layer.sublayers[0].sublayers[2].backgroundColor = [UIColor colorWithWhite:1 alpha:0.65].CGColor;
 }
 - (void)cameraDragged:(UIPanGestureRecognizer*)sender {
+
+  if ( isiPad ) {
+    return;
+  }
+
   CGPoint translatedPoint = [sender translationInView:self.view];
   translatedPoint = CGPointMake(self.view.center.x, self.view.center.y + translatedPoint.y);
 
@@ -197,6 +205,11 @@
   }
 }
 - (void)cameraTapped:(UITapGestureRecognizer*)sender {
+
+  if ( isiPad ) {
+    return;
+  }
+
   if (sender.state == UIGestureRecognizerStateEnded) {
     [UIView animateWithDuration:0.2 animations:^{
       [self.view setCenter:CGPointMake(self.view.center.x, self.view.center.y - 20)];


### PR DESCRIPTION
These changes are only applied to iPad's. iPhones will not change in any way.
Hide camera slider/disable functionality with the slider
Makes Time font Bigger.
Fixes the extremely long slider.

-tested on an iPad Pro 10.5", iPad Air 1st Gen, and an iPhone X

Some pictures:

[iPad Pro Landscape](https://i.ibb.co/hZnYHmL/2017-FD30-1012-4428-831-D-61-DEAB981407.png)

[iPad Pro Portrait](https://i.ibb.co/wN4tRHg/12915048-8-ADD-4058-BF1-C-C9-B9-DA64821-D.png)

[iPad Air](https://i.ibb.co/Hnzy4Vy/65486276-EDD8-4-B6-D-8-CF4-A1-F6-E7-D687-B5.png)

[iPhone X(just to prove that nothing changes on iPhones)](https://i.ibb.co/PCph9BT/AD1-FE46-B-F2-F3-4-FAB-99-AD-7615-B997-B58-B.png)

Don't go to hard on me ;p, my obj-c knowledge is very little.

