### PR TITLE
Fix For Passcode Screen

### DIFF
--- a/LockScreen.xm
+++ b/LockScreen.xm
@@ -301,6 +301,7 @@ static void setIsLocked(bool locked) {
 - (void)viewWillAppear:(BOOL)arg1 {
   %orig;
   if (enabled) {
+    unlockAllowed = YES;
     [mainPageView.sixController hideBars];
   }
 }


### PR DESCRIPTION
There is a bug occurs when Touch ID fails or after respring. As a result of those errors, Posscode screen appears. Even though passcode entered correctly, homepage doesn't appear. I believe this piece of code prevent this bug. Because If any user end up at passcode screen should pass the lockscreen.